### PR TITLE
Add workflow to check deadlinks

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,17 @@
+name: Check dead links
+
+on:
+  workflow_dispatch:
+  push:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  md-dead-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: AlexanderDokuchaev/md-dead-link-check@v1.2.0


### PR DESCRIPTION
Adds a github action that checks for dead links:

* Every there is a push
* First day of each month
* And can be run when triggered

[Here](https://github.com/kaitj/styxbook/actions/runs/14221242756/job/39849538442) is an example of where it ran.
